### PR TITLE
Fix for httpHandler branch

### DIFF
--- a/http/Program.cs
+++ b/http/Program.cs
@@ -18,14 +18,13 @@ class HttpWasm {
         WasiHttpExperimental.Close(handle);
     }
 
-    unsafe static void Main(string[] args) {
+    static async Task Main(string[] args) {
         // lowLevel();
         
         // high level example.
         var client = new HttpClient(new WasiHttpHandler());
-        var task = client.GetAsync("https://postman-echo.com/get", System.Threading.CancellationToken.None);
-        task.Wait();
-        Console.WriteLine(task.Result);
+        var result = await client.GetAsync("https://postman-echo.com/get", System.Threading.CancellationToken.None);
+        Console.WriteLine(result);
     }
 }
 


### PR DESCRIPTION
This is the same workaround I've used in other places on dotnet-wasi-sdk. For example, this is doing inbound HTTP: https://github.com/dotnet/dotnet-wasi-sdk/blob/972c448c5ae2dafd2dc7fdf14eb0e09f155a9386/src/Wasi.AspNetCore.Server.Native/native/interop.c#L11

I verified by building https://github.com/brendandburns/wasmtime and running `WASI_HTTP_ALLOWED_HOSTS=https://postman-echo.com wasmtime --dir . --wasi-modules=experimental-wasi-http bin/Debug/net7.0/http.wasm`. Output:

```
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.EmptyContent, Headers:
{
  Content-Length: 0
}
```

I think `Content-Length: 0` is because it doesn't yet have an implementation to read the response data.

One question about wasi_experimental_http: I know this is an external API that you're not responsible for, but I was surprised to see that it blocks until the response is received (at least, the headers). That makes it unlikely to be practical for real use, since concurrent requests would not be possible. Assuming I'm interpreting this correctly, do you know if there's a plan to change this into something that supports concurrency?