### PR TITLE
Install libxml2 into container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
         },
         "ghcr.io/devcontainers/features/common-utils": {}
     },
+    "postCreateCommand": "apt-get install -y libxml2",
     "customizations": {
         "vscode": {
 	    "extensions": [ "ms-dotnettools.csharp" ]


### PR DESCRIPTION
Install libxml2 into container via "postCreateCommand".

Why: 
`mcr.microsoft.com/dotnet/sdk:7.0` lacks libxml2 package, causing `dotnet build` to fail:

```
/root/.wasi-sdk/wasi-sdk-16.0/bin/wasm-ld: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory
```

Or is there a more idiomatic solution other than `postCreateCommand`?


BTW, thank you @brendandburns for devcontainers you've created!